### PR TITLE
hostname was getting set to the puppet master's fqdn in my case...

### DIFF
--- a/lib/puppet-rundeck.rb
+++ b/lib/puppet-rundeck.rb
@@ -72,7 +72,7 @@ class PuppetRundeck < Sinatra::Base
       osVersion="#{xml_escape(facts.values["operatingsystemrelease"])}"
       tags="#{xml_escape([n.environment, tags.join(',')].join(','))}"
       username="#{xml_escape(PuppetRundeck.username)}"
-      hostname="#{xml_escape(facts.values["fqdn"])}"/>
+      hostname="#{xml_escape(n.name)}"/>
 EOH
     end
     response << "</project>"


### PR DESCRIPTION
I did find what seemed to be a bug… The resource file your program generated for me had the "hostname" parameter set to the puppet master, rather than the node, i.e. I had node like

```
<node name="events1003.impermium.com" 
    type="Node"
    description="events1003.impermium.com"
    …
    hostname="puppet.impermium.com"
/>
```

It was the same for all my nodes.

When I changed the following line from `facts.values["fqdn"]` to just `n.name`, it resolved the problem for me, but I assume this bug was due to a misconfiguration on my end rather than yours...
