### PR TITLE
Selective tags

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -54,6 +54,11 @@ To use with RunDeck specify the target URL as the value of the `project.resource
 
    project.resources.url = http://localhost:8144
 
+Yo can also specify a required tag to filter the node list, to provide different project URLs based
+on the same puppet server and puppet-rundeck instance:
+
+   project.resources.url = http://localhost:8144/tag/production
+
 You can specify some configuration options:
 
 * -c or --config to override the default Puppet configuration file (defaults to `/etc/puppet/puppet.conf`)

--- a/lib/puppet-rundeck.rb
+++ b/lib/puppet-rundeck.rb
@@ -42,8 +42,7 @@ class PuppetRundeck < Sinatra::Base
     return input.to_s.to_xs
   end
 
-  require 'pp'
-  get '/' do
+  def respond(required_tag=nil)
     response['Content-Type'] = 'text/xml'
     response_xml = %Q(<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE project PUBLIC "-//DTO Labs Inc.//DTD Resources Document 1.0//EN" "project.dtd">\n<project>\n)
       # Fix for 2.6 to 2.7 indirection difference
@@ -60,6 +59,9 @@ class PuppetRundeck < Sinatra::Base
           tags = Puppet::Resource::Catalog.find(n.name).tags
         else
           tags = Puppet::Resource::Catalog.indirection.find(n.name).tags
+        end
+        if ! required_tag.nil?
+          next if ! tags.include? required_tag
         end
         facts = n.parameters
         os_family = facts["kernel"] =~ /windows/i ? 'windows' : 'unix'
@@ -79,4 +81,15 @@ EOH
     response_xml << "</project>"
     response_xml
   end
+
+  require 'pp'
+
+  get '/' do
+    respond
+  end
+
+  get '/tag/:tag' do
+    respond(params[:tag])
+  end
+
 end


### PR DESCRIPTION
Hi James,

Another tweak that we have a use case for where I work. This one is so you can generate, using the same puppet-rundeck instance, a project xml file with a subset of nodes based on a tag:

% curl http://localhost:8144/tag/project1

Cheers,
Anthony
